### PR TITLE
Null bytes fix, updated to SR28 data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ data_cleanup:
 	go build -o data_cleanup data_cleanup.go
 
 sr26.zip:
-	curl -O https://www.ars.usda.gov/SP2UserFiles/Place/12354500/Data/SR26/dnload/sr26.zip
+	curl -O https://www.ars.usda.gov/ARSUserFiles/80400525/Data/SR/SR28/dnload/sr28asc.zip
 
 sr26: sr26.zip
 	mkdir sr26
-	tar -C sr26 -xvf sr26.zip
+	tar -C sr26 -xvf sr28asc.zip
 
 data_src.csv: sr26 data_cleanup
 	$(C) sr26/DATA_SRC.txt data_src.csv

--- a/data_cleanup.go
+++ b/data_cleanup.go
@@ -35,6 +35,9 @@ func main() {
 
 	for err == nil {
 		r, _, err = rd.ReadRune()
+		if err != nil {
+			break
+		}
 		switch r {
 		case '"':
 			switch lastR {

--- a/import.sql
+++ b/import.sql
@@ -2,17 +2,17 @@ BEGIN;
 
     SET CONSTRAINTS ALL DEFERRED;
 
-    COPY food_groups FROM '/Users/eric/code/nutr/sr26/fd_group.csv' DELIMITER '	' CSV;
-    COPY foods FROM '/Users/eric/code/nutr/sr26/food_des.csv' DELIMITER '	' CSV;
-    COPY langua_l_desc FROM '/Users/eric/code/nutr/sr26/langdesc.csv' DELIMITER '	' CSV;
-    COPY langua_l_factors FROM '/Users/eric/code/nutr/sr26/langual.csv' DELIMITER '	' CSV;
-    COPY nutrients FROM '/Users/eric/code/nutr/sr26/nutr_def.csv' DELIMITER '	' CSV;
-    COPY source_codes FROM '/Users/eric/code/nutr/sr26/src_cd.csv' DELIMITER '	' CSV;
-    COPY data_derivation_codes FROM '/Users/eric/code/nutr/sr26/deriv_cd.csv' DELIMITER '	' CSV;
-    COPY nutrient_data FROM '/Users/eric/code/nutr/sr26/nut_data.csv' DELIMITER '	' CSV;
-    COPY weights FROM '/Users/eric/code/nutr/sr26/weight.csv' DELIMITER '	' CSV;
-    COPY footnotes FROM '/Users/eric/code/nutr/sr26/footnote.csv' DELIMITER '	' CSV;
-    COPY sources_of_data FROM '/Users/eric/code/nutr/sr26/data_src.csv' DELIMITER '	' CSV;
-    COPY sources_of_data_assoc FROM '/Users/eric/code/nutr/sr26/datsrcln.csv' DELIMITER '	' CSV;
+    COPY food_groups FROM '/Users/brianglusman/open_pantry/nutes/fd_group.csv' DELIMITER '	' CSV;
+    COPY foods FROM '/Users/brianglusman/open_pantry/nutes/food_des.csv' DELIMITER '	' CSV;
+    COPY langua_l_desc FROM '/Users/brianglusman/open_pantry/nutes/langdesc.csv' DELIMITER '	' CSV;
+    COPY langua_l_factors FROM '/Users/brianglusman/open_pantry/nutes/langual.csv' DELIMITER '	' CSV;
+    COPY nutrients FROM '/Users/brianglusman/open_pantry/nutes/nutr_def.csv' DELIMITER '	' CSV;
+    COPY source_codes FROM '/Users/brianglusman/open_pantry/nutes/src_cd.csv' DELIMITER '	' CSV;
+    COPY data_derivation_codes FROM '/Users/brianglusman/open_pantry/nutes/deriv_cd.csv' DELIMITER '	' CSV;
+    COPY nutrient_data FROM '/Users/brianglusman/open_pantry/nutes/nut_data.csv' DELIMITER '	' CSV;
+    COPY weights FROM '/Users/brianglusman/open_pantry/nutes/weight.csv' DELIMITER '	' CSV;
+    COPY footnotes FROM '/Users/brianglusman/open_pantry/nutes/footnote.csv' DELIMITER '	' CSV;
+    COPY sources_of_data FROM '/Users/brianglusman/open_pantry/nutes/data_src.csv' DELIMITER '	' CSV;
+    COPY sources_of_data_assoc FROM '/Users/brianglusman/open_pantry/nutes/datsrcln.csv' DELIMITER '	' CSV;
 
 COMMIT;


### PR DESCRIPTION
You probably won't want to merge this in as is, but thought it was worth PRing back as it's got newer data, a bug fix, and helps point out one thing not documented, that import.sql has hardcoded paths to your personal machine... If I have time, maybe I'll come back and update this so the Makefile generates the import.sql file from a template or something?  and/or update the path names so sr28 is reflected instead of the quick fix I did, but for you or anyone else looking at the data set, this may save some work.  Thanks for the tool!